### PR TITLE
Use binary-search library and add smoke tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
+        "binary-search": "^1.3.6",
         "lodash": "^4.17.21",
         "optimization-js": "github:yeatmanlab/optimization-js",
         "seedrandom": "^3.0.5"
@@ -3302,6 +3303,11 @@
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "node_modules/binary-search": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
     },
     "node_modules/bl": {
       "version": "1.2.3",
@@ -19300,6 +19306,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "binary-search": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
     },
     "bl": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "binary-search": "^1.3.6",
     "lodash": "^4.17.21",
     "optimization-js": "github:yeatmanlab/optimization-js",
     "seedrandom": "^3.0.5"

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -139,7 +139,7 @@ describe('Cat', () => {
     expect(cat7.theta).toBeCloseTo(0.25, 1);
   });
 
-  it('should return a error if is invalid action', () => {
+  it('should throw a error if zeta and answers do not have matching length', () => {
     try {
       cat7.updateAbilityEstimate(
         [
@@ -153,9 +153,44 @@ describe('Cat', () => {
     }
   });
 
-  it('should return a error if is invalid action', () => {
+  it('should throw a error if method is invalid', () => {
+    try {
+      new Cat({ method: 'coolMethod' });
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+    }
+
+    try {
+      cat7.updateAbilityEstimate(
+        [
+          { a: 1, b: -4.0, c: 0.5, d: 1 },
+          { a: 1, b: -3.0, c: 0.5, d: 1 },
+        ],
+        [0, 0],
+        'coolMethod',
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+    }
+  });
+
+  it('should throw a error if itemSelect is invalid', () => {
+    try {
+      new Cat({ itemSelect: 'coolMethod' });
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+    }
+
     try {
       cat7.findNextItem(stimuli, 'coolMethod');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+    }
+  });
+
+  it('should throw a error if startSelect is invalid', () => {
+    try {
+      new Cat({ startSelect: 'coolMethod' });
     } catch (error) {
       expect(error).toBeInstanceOf(Error);
     }

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -19,9 +19,23 @@ describe('fisherInformation', () => {
 });
 
 describe('findClosest', () => {
-  it('correctly selects the one item closest to the target', () => {
-    expect(1).toBeCloseTo(
-      findClosest([{ difficulty: 1 }, { difficulty: 4 }, { difficulty: 10 }, { difficulty: 11 }], 5),
+  it('correctly selects the first item if appropriate', () => {
+    expect(0).toBe(findClosest([{ difficulty: 1 }, { difficulty: 4 }, { difficulty: 10 }, { difficulty: 11 }], 0));
+  });
+  it('correctly selects the last item if appropriate', () => {
+    expect(3).toBe(findClosest([{ difficulty: 1 }, { difficulty: 4 }, { difficulty: 10 }, { difficulty: 11 }], 1000));
+  });
+  it('correctly selects a middle item if it equals exactly', () => {
+    expect(2).toBe(findClosest([{ difficulty: 1 }, { difficulty: 4 }, { difficulty: 10 }, { difficulty: 11 }], 10));
+  });
+  it('correctly selects the one item closest to the target if less than', () => {
+    expect(1).toBe(
+      findClosest([{ difficulty: 1.1 }, { difficulty: 4.2 }, { difficulty: 10.3 }, { difficulty: 11.4 }], 5.1),
+    );
+  });
+  it('correctly selects the one item closest to the target if greater than', () => {
+    expect(2).toBe(
+      findClosest([{ difficulty: 1.1 }, { difficulty: 4.2 }, { difficulty: 10.3 }, { difficulty: 11.4 }], 9.1),
     );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,8 +125,8 @@ export class Cat {
 
   /**
    * use previous response patterns and item params to calculate the estimate ability based on a defined method
-   * @param answer - last response pattern
    * @param zeta - last item param
+   * @param answer - last response pattern
    * @param method
    */
   public updateAbilityEstimate(zeta: Zeta | Zeta[], answer: (0 | 1) | (0 | 1)[], method: string = this.method) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
+import bs from 'binary-search';
 import { Stimulus, Zeta } from './type';
+
 /**
  * calculates the probability that someone with a given ability level theta will answer correctly an item. Uses the 4 parameters logistic model
  * @param theta - ability estimate
@@ -44,42 +46,46 @@ export const normal = (mean = 0, stdDev = 1, min = -4, max = 4, stepSize = 0.1) 
 
 /**
  * find the item in a given array that has the difficulty closest to the target value
- * @param arr Array<Stimulus> - an array of stimulus
+ *
+ * @remarks
+ * The input array of stimuli must be sorted by difficulty.
+ *
+ * @param arr Array<Stimulus> - an array of stimuli sorted by difficulty
  * @param target number - ability estimate
  * @returns {number} the index of arr
  */
 export const findClosest = (arr: Array<Stimulus>, target: number) => {
-  const n = arr.length;
-  // Corner cases
-  if (target <= arr[0].difficulty) return 0;
-  if (target >= arr[n - 1].difficulty) return n - 1;
-  // Doing binary search
-  let i = 0,
-    j = n,
-    mid = 0;
-  while (i < j) {
-    mid = Math.ceil((i + j) / 2);
-    if (arr[mid].difficulty == target) return mid;
-    // If target is less than array
-    // element,then search in left
-    if (target < arr[mid].difficulty) {
-      // If target is greater than previous
-      // to mid, return closest of two
-      if (mid > 0 && target > arr[mid - 1].difficulty) return getClosest(arr, mid - 1, mid, target);
-      // Repeat for left half
-      j = mid;
-    }
-    // If target is greater than mid
-    else {
-      if (mid < n - 1 && target < arr[mid + 1].difficulty) return getClosest(arr, mid, mid + 1, target);
-      i = mid + 1; // update i
+  // Let's consider the edge cases first
+  if (target <= arr[0].difficulty) {
+    return 0;
+  } else if (target >= arr[arr.length - 1].difficulty) {
+    return arr.length - 1;
+  }
+
+  const comparitor = (element: Stimulus, needle: number) => {
+    return element.difficulty - needle;
+  };
+  const indexOfTarget = bs(arr, target, comparitor);
+
+  if (indexOfTarget >= 0) {
+    // `bs` returns a positive integer index if it found an exact match.
+    return indexOfTarget;
+  } else {
+    // If the value is not in the array, then -(index + 1) is returned, where
+    // index is where the value should be inserted into the array to maintain
+    // sorted order. Thus, the target is between the values at
+    const lowIndex = -2 - indexOfTarget;
+    const highIndex = -1 - indexOfTarget;
+
+    // So we simply compare the differences between the target and the high and
+    // low values, respectively
+    const lowDiff = Math.abs(arr[lowIndex].difficulty - target);
+    const highDiff = Math.abs(arr[highIndex].difficulty - target);
+
+    if (lowDiff < highDiff) {
+      return lowIndex;
+    } else {
+      return highIndex;
     }
   }
-  // Only single element left after sear
-  return mid;
-};
-
-const getClosest = (arr: Array<Stimulus>, val1: number, val2: number, target: number) => {
-  if (target - arr[val1].difficulty >= arr[val2].difficulty - target) return val2;
-  else return val1;
 };


### PR DESCRIPTION
This PR
- Uses the binary-search library instead of implementing our own
- Add smoke tests to `Cat` to increase test coverage