### PR TITLE
Use validated lowercase method in CAT constructor

### DIFF
--- a/src/cat.ts
+++ b/src/cat.ts
@@ -79,7 +79,7 @@ export class Cat {
     this._seMeasurement = Number.MAX_VALUE;
     this.nStartItems = nStartItems;
     this._rng = randomSeed === null ? seedrandom() : seedrandom(randomSeed);
-    this._prior = method === 'eap' ? Cat.validatePrior(priorDist, priorPar, minTheta, maxTheta) : [];
+    this._prior = this.method === 'eap' ? Cat.validatePrior(priorDist, priorPar, minTheta, maxTheta) : [];
   }
 
   public get theta() {


### PR DESCRIPTION
This PR fixes an issue where the prior was not being set when the CAT method was `"EAP"` (upper case letters). Now the comparison is made against the validated lower-case method.