### PR TITLE
Centralize zeta parameter numeric conversion

### DIFF
--- a/src/__tests__/corpus.test.ts
+++ b/src/__tests__/corpus.test.ts
@@ -115,11 +115,11 @@ describe('fillZetaDefaults', () => {
 describe('ensureZetaNumericValues', () => {
   it('converts string numbers to numeric values', () => {
     const zeta: Zeta = {
-      a: '1.5' as any,
-      b: '2.0' as any,
-      c: '0.25' as any,
-      d: '0.95' as any,
-    };
+      a: '1.5',
+      b: '2.0',
+      c: '0.25',
+      d: '0.95',
+    } as unknown as Zeta;
 
     const result = ensureZetaNumericValues(zeta);
 
@@ -167,9 +167,9 @@ describe('ensureZetaNumericValues', () => {
   it('filters out null values', () => {
     const zeta: Zeta = {
       a: 1.5,
-      b: null as any,
+      b: null,
       c: 0.25,
-    };
+    } as unknown as Zeta;
 
     const result = ensureZetaNumericValues(zeta);
 
@@ -182,9 +182,9 @@ describe('ensureZetaNumericValues', () => {
   it('filters out empty string values', () => {
     const zeta: Zeta = {
       a: 1.5,
-      b: '' as any,
+      b: '',
       c: 0.25,
-    };
+    } as unknown as Zeta;
 
     const result = ensureZetaNumericValues(zeta);
 
@@ -197,11 +197,11 @@ describe('ensureZetaNumericValues', () => {
   it('filters out NA values (case insensitive)', () => {
     const zeta: Zeta = {
       a: 1.5,
-      b: 'NA' as any,
-      c: 'na' as any,
-      d: 'Na' as any,
+      b: 'NA',
+      c: 'na',
+      d: 'Na',
       discrimination: 2.0,
-    };
+    } as unknown as Zeta;
 
     const result = ensureZetaNumericValues(zeta);
 
@@ -231,10 +231,10 @@ describe('ensureZetaNumericValues', () => {
   it('filters out non-numeric string values', () => {
     const zeta: Zeta = {
       a: 1.5,
-      b: 'not-a-number' as any,
-      c: 'abc' as any,
+      b: 'not-a-number',
+      c: 'abc',
       d: 0.95,
-    };
+    } as unknown as Zeta;
 
     const result = ensureZetaNumericValues(zeta);
 
@@ -246,11 +246,11 @@ describe('ensureZetaNumericValues', () => {
 
   it('handles mixed symbolic and semantic parameter names', () => {
     const zeta: Zeta = {
-      a: '1.5' as any,
-      difficulty: '2.0' as any,
-      c: 'invalid' as any,
-      slipping: '0.95' as any,
-    };
+      a: '1.5',
+      difficulty: '2.0',
+      c: 'invalid',
+      slipping: '0.95',
+    } as unknown as Zeta;
 
     const result = ensureZetaNumericValues(zeta);
 
@@ -264,10 +264,10 @@ describe('ensureZetaNumericValues', () => {
   it('returns empty object when all values are invalid', () => {
     const zeta: Zeta = {
       a: undefined,
-      b: null as any,
-      c: 'NA' as any,
+      b: null,
+      c: 'NA',
       d: NaN,
-    };
+    } as unknown as Zeta;
 
     const result = ensureZetaNumericValues(zeta);
 
@@ -277,10 +277,10 @@ describe('ensureZetaNumericValues', () => {
   it('handles zero values correctly', () => {
     const zeta: Zeta = {
       a: 0,
-      b: '0' as any,
+      b: '0',
       c: 0.0,
-      d: '0.0' as any,
-    };
+      d: '0.0',
+    } as unknown as Zeta;
 
     const result = ensureZetaNumericValues(zeta);
 
@@ -295,9 +295,9 @@ describe('ensureZetaNumericValues', () => {
   it('handles negative values correctly', () => {
     const zeta: Zeta = {
       a: -1.5,
-      b: '-2.0' as any,
+      b: '-2.0',
       c: 0.25,
-    };
+    } as unknown as Zeta;
 
     const result = ensureZetaNumericValues(zeta);
 

--- a/src/__tests__/corpus.test.ts
+++ b/src/__tests__/corpus.test.ts
@@ -7,6 +7,7 @@ import {
   convertZeta,
   checkNoDuplicateCatNames,
   filterItemsByCatParameterAvailability,
+  ensureZetaNumericValues,
 } from '../corpus';
 import { prepareClowderCorpus } from '..';
 import _omit from 'lodash/omit';
@@ -107,6 +108,203 @@ describe('fillZetaDefaults', () => {
       b: 5,
       c: 0,
       d: 1,
+    });
+  });
+});
+
+describe('ensureZetaNumericValues', () => {
+  it('converts string numbers to numeric values', () => {
+    const zeta: Zeta = {
+      a: '1.5' as any,
+      b: '2.0' as any,
+      c: '0.25' as any,
+      d: '0.95' as any,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({
+      a: 1.5,
+      b: 2.0,
+      c: 0.25,
+      d: 0.95,
+    });
+  });
+
+  it('preserves numeric values', () => {
+    const zeta: Zeta = {
+      a: 1.5,
+      b: 2.0,
+      c: 0.25,
+      d: 0.95,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({
+      a: 1.5,
+      b: 2.0,
+      c: 0.25,
+      d: 0.95,
+    });
+  });
+
+  it('filters out undefined values', () => {
+    const zeta: Zeta = {
+      a: 1.5,
+      b: undefined,
+      c: 0.25,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({
+      a: 1.5,
+      c: 0.25,
+    });
+  });
+
+  it('filters out null values', () => {
+    const zeta: Zeta = {
+      a: 1.5,
+      b: null as any,
+      c: 0.25,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({
+      a: 1.5,
+      c: 0.25,
+    });
+  });
+
+  it('filters out empty string values', () => {
+    const zeta: Zeta = {
+      a: 1.5,
+      b: '' as any,
+      c: 0.25,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({
+      a: 1.5,
+      c: 0.25,
+    });
+  });
+
+  it('filters out NA values (case insensitive)', () => {
+    const zeta: Zeta = {
+      a: 1.5,
+      b: 'NA' as any,
+      c: 'na' as any,
+      d: 'Na' as any,
+      discrimination: 2.0,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({
+      a: 1.5,
+      discrimination: 2.0,
+    });
+  });
+
+  it('filters out non-finite values (Infinity, -Infinity, NaN)', () => {
+    const zeta: Zeta = {
+      a: 1.5,
+      b: Infinity,
+      c: -Infinity,
+      d: NaN,
+      discrimination: 2.0,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({
+      a: 1.5,
+      discrimination: 2.0,
+    });
+  });
+
+  it('filters out non-numeric string values', () => {
+    const zeta: Zeta = {
+      a: 1.5,
+      b: 'not-a-number' as any,
+      c: 'abc' as any,
+      d: 0.95,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({
+      a: 1.5,
+      d: 0.95,
+    });
+  });
+
+  it('handles mixed symbolic and semantic parameter names', () => {
+    const zeta: Zeta = {
+      a: '1.5' as any,
+      difficulty: '2.0' as any,
+      c: 'invalid' as any,
+      slipping: '0.95' as any,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({
+      a: 1.5,
+      difficulty: 2.0,
+      slipping: 0.95,
+    });
+  });
+
+  it('returns empty object when all values are invalid', () => {
+    const zeta: Zeta = {
+      a: undefined,
+      b: null as any,
+      c: 'NA' as any,
+      d: NaN,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({});
+  });
+
+  it('handles zero values correctly', () => {
+    const zeta: Zeta = {
+      a: 0,
+      b: '0' as any,
+      c: 0.0,
+      d: '0.0' as any,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({
+      a: 0,
+      b: 0,
+      c: 0,
+      d: 0,
+    });
+  });
+
+  it('handles negative values correctly', () => {
+    const zeta: Zeta = {
+      a: -1.5,
+      b: '-2.0' as any,
+      c: 0.25,
+    };
+
+    const result = ensureZetaNumericValues(zeta);
+
+    expect(result).toEqual({
+      a: -1.5,
+      b: -2.0,
+      c: 0.25,
     });
   });
 });

--- a/src/cat.ts
+++ b/src/cat.ts
@@ -2,7 +2,7 @@
 import { minimize_Powell } from 'optimization-js';
 import { Stimulus, Zeta } from './type';
 import { itemResponseFunction, fisherInformation, normal, uniform, findClosest } from './utils';
-import { validateZetaParams, fillZetaDefaults } from './corpus';
+import { validateZetaParams, fillZetaDefaults, ensureZetaNumericValues } from './corpus';
 import seedrandom from 'seedrandom';
 import _clamp from 'lodash/clamp';
 import _cloneDeep from 'lodash/cloneDeep';
@@ -183,6 +183,8 @@ export class Cat {
     zeta = Array.isArray(zeta) ? zeta : [zeta];
     answer = Array.isArray(answer) ? answer : [answer];
 
+    // Ensure zeta parameters are numbers to prevent string concatenation issues
+    zeta = zeta.map((z) => ensureZetaNumericValues(z));
     zeta.forEach((z) => validateZetaParams(z, true));
 
     if (zeta.length !== answer.length) {


### PR DESCRIPTION
## Problem

`Zeta` parameters (item parameters like a, b, c, d) were sometimes being passed as strings instead of numbers, causing string concatenation instead of mathematical addition. This led to errors in IRT calculations where parameters would be concatenated (e.g., "1" + "2" = "12") rather than added (1 + 2 = 3).

## Solution

We created a centralized utility function `ensureZetaNumericValues()` that:

- Converts all zeta parameter values to numbers
- Filters out invalid values (`undefined`, `null`, empty strings, 'NA', Infinity, NaN)
- Provides a single source of truth for zeta parameter processing

We called the `ensureZetaNumericValues()` in `prepareClowderCorpus()` and in `Cat.updateAbilityEstimate()` to convert zeta parameters before validation.

Having one utility function enforces DRY principles. This change is backwards compatible. All previous tests pass. New tests were added to corpus.test.ts.