### PR TITLE
ENH additionalItemsToRemove param

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ const nextItem = clowder.updateCatAndGetNextItem({
   catsToUpdate: ['cat1', 'cat2'], // Update responses for both Cats
   items: [clowder.corpus[0]], // Previously seen item
   answers: [1], // Response for the previously seen item
+  additionalItemsToRemove: [clowder.corpus[3]], // Optional: Remove items without updating ability estimates
 });
 
 console.log('Next item to present:', nextItem);
@@ -259,6 +260,34 @@ console.log('Next item to present:', nextItem);
 if (clowder.earlyStopping?.earlyStop) {
   console.log('Early stopping triggered:', clowder.stoppingReason);
 }
+```
+
+### 4. Managing Item Removal with `additionalItemsToRemove`
+
+The `additionalItemsToRemove` parameter allows you to remove items from the remaining corpus without updating ability estimates. This is useful for excluding items that should not be presented again (e.g., items that were skipped, flagged, or excluded for other reasons).
+
+#### Key Characteristics:
+
+- **Does not affect ability estimates**: Items in `additionalItemsToRemove` are removed from the corpus but do not contribute to Cat ability updates.
+- **Does not add to seenItems**: These items are not tracked in the `seenItems` array.
+- **Cumulative removal**: Multiple calls to `updateCatAndGetNextItem` with `additionalItemsToRemove` will cumulatively remove items.
+
+#### Example Usage:
+
+```typescript
+// Remove items that were skipped or flagged without updating ability estimates
+const nextItem = clowder.updateCatAndGetNextItem({
+  catToSelect: 'cat1',
+  catsToUpdate: ['cat1'],
+  items: [clowder.corpus[0]], // Item that was presented and answered
+  answers: [1],
+  additionalItemsToRemove: [clowder.corpus[2], clowder.corpus[3]], // Items to exclude without updating ability
+});
+
+// After this call:
+// - clowder.corpus[0] is in seenItems and was used to update cat1's ability
+// - clowder.corpus[2] and clowder.corpus[3] are removed from remainingItems but NOT in seenItems
+// - Only clowder.corpus[1] and any other items remain available for selection
 ```
 
 ---

--- a/src/__tests__/clowder.test.ts
+++ b/src/__tests__/clowder.test.ts
@@ -765,3 +765,272 @@ describe('Clowder Early Stopping', () => {
     expect(nextItem).toBeUndefined(); // Should return undefined when early stopping triggers
   });
 });
+
+describe('Clowder additionalItemsToRemove parameter', () => {
+  it('should remove additional items from remainingItems when additionalItemsToRemove is provided', () => {
+    const clowderInput: ClowderInput = {
+      cats: {
+        cat1: { method: 'MLE', theta: 0.5 },
+      },
+      corpus: [
+        createMultiZetaStimulus('0', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('1', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('2', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('3', [createZetaCatMap(['cat1'])]),
+      ],
+    };
+
+    const clowder = new Clowder(clowderInput);
+
+    // Remove items 0 and 2 using additionalItemsToRemove
+    clowder.updateCatAndGetNextItem({
+      catToSelect: 'cat1',
+      additionalItemsToRemove: [clowder.corpus[0], clowder.corpus[2]],
+    });
+
+    // Should have 2 remaining items (1 and 3)
+    expect(clowder.remainingItems).toHaveLength(2);
+    expect(clowder.remainingItems.map((item) => item.id)).toEqual(['1', '3']);
+  });
+
+  it('should remove additional items along with presented items', () => {
+    const clowderInput: ClowderInput = {
+      cats: {
+        cat1: { method: 'MLE', theta: 0.5 },
+      },
+      corpus: [
+        createMultiZetaStimulus('0', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('1', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('2', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('3', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('4', [createZetaCatMap(['cat1'])]),
+      ],
+    };
+
+    const clowder = new Clowder(clowderInput);
+
+    // Present item 0 and additionally remove items 2 and 3
+    clowder.updateCatAndGetNextItem({
+      catToSelect: 'cat1',
+      catsToUpdate: ['cat1'],
+      items: [clowder.corpus[0]],
+      answers: [1],
+      additionalItemsToRemove: [clowder.corpus[2], clowder.corpus[3]],
+    });
+
+    // Should have 2 remaining items (1 and 4)
+    expect(clowder.remainingItems).toHaveLength(2);
+    expect(clowder.remainingItems.map((item) => item.id)).toEqual(['1', '4']);
+    // Item 0 should be in seenItems
+    expect(clowder.seenItems).toHaveLength(1);
+    expect(clowder.seenItems[0].id).toBe('0');
+  });
+
+  it('should not add additional items to seenItems', () => {
+    const clowderInput: ClowderInput = {
+      cats: {
+        cat1: { method: 'MLE', theta: 0.5 },
+      },
+      corpus: [
+        createMultiZetaStimulus('0', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('1', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('2', [createZetaCatMap(['cat1'])]),
+      ],
+    };
+
+    const clowder = new Clowder(clowderInput);
+
+    clowder.updateCatAndGetNextItem({
+      catToSelect: 'cat1',
+      additionalItemsToRemove: [clowder.corpus[0], clowder.corpus[1]],
+    });
+
+    // Only the presented items should be in seenItems (none in this case)
+    expect(clowder.seenItems).toHaveLength(0);
+  });
+
+  it('should handle empty additionalItemsToRemove array', () => {
+    const clowderInput: ClowderInput = {
+      cats: {
+        cat1: { method: 'MLE', theta: 0.5 },
+      },
+      corpus: [
+        createMultiZetaStimulus('0', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('1', [createZetaCatMap(['cat1'])]),
+      ],
+    };
+
+    const clowder = new Clowder(clowderInput);
+
+    clowder.updateCatAndGetNextItem({
+      catToSelect: 'cat1',
+      additionalItemsToRemove: [],
+    });
+
+    // All items should remain
+    expect(clowder.remainingItems).toHaveLength(2);
+  });
+
+  it('should handle additionalItemsToRemove with no items parameter', () => {
+    const clowderInput: ClowderInput = {
+      cats: {
+        cat1: { method: 'MLE', theta: 0.5 },
+      },
+      corpus: [
+        createMultiZetaStimulus('0', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('1', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('2', [createZetaCatMap(['cat1'])]),
+      ],
+    };
+
+    const clowder = new Clowder(clowderInput);
+
+    clowder.updateCatAndGetNextItem({
+      catToSelect: 'cat1',
+      additionalItemsToRemove: [clowder.corpus[0]],
+    });
+
+    // Item 0 should be removed, but not added to seenItems
+    expect(clowder.remainingItems).toHaveLength(2);
+    expect(clowder.seenItems).toHaveLength(0);
+  });
+
+  it('should remove items with multiple zeta parameters', () => {
+    const clowderInput: ClowderInput = {
+      cats: {
+        cat1: { method: 'MLE', theta: 0.5 },
+        cat2: { method: 'MLE', theta: 0.5 },
+      },
+      corpus: [
+        createMultiZetaStimulus('0', [createZetaCatMap(['cat1', 'cat2'])]),
+        createMultiZetaStimulus('1', [createZetaCatMap(['cat1']), createZetaCatMap(['cat2'])]),
+        createMultiZetaStimulus('2', [createZetaCatMap(['cat1', 'cat2'])]),
+      ],
+    };
+
+    const clowder = new Clowder(clowderInput);
+
+    clowder.updateCatAndGetNextItem({
+      catToSelect: 'cat1',
+      additionalItemsToRemove: [clowder.corpus[0]],
+    });
+
+    expect(clowder.remainingItems).toHaveLength(2);
+    expect(clowder.remainingItems.map((item) => item.id)).toEqual(['1', '2']);
+  });
+
+  it('should correctly handle additionalItemsToRemove with unvalidated items', () => {
+    const clowderInput: ClowderInput = {
+      cats: {
+        cat1: { method: 'MLE', theta: 0.5 },
+      },
+      corpus: [
+        createMultiZetaStimulus('0', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('1', [createZetaCatMap([])]), // Unvalidated
+        createMultiZetaStimulus('2', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('3', [createZetaCatMap([])]), // Unvalidated
+      ],
+    };
+
+    const clowder = new Clowder(clowderInput);
+
+    clowder.updateCatAndGetNextItem({
+      catToSelect: 'cat1',
+      additionalItemsToRemove: [clowder.corpus[1], clowder.corpus[3]],
+    });
+
+    // Should have 2 remaining items (0 and 2, both validated)
+    expect(clowder.remainingItems).toHaveLength(2);
+    expect(clowder.remainingItems.map((item) => item.id)).toEqual(['0', '2']);
+  });
+
+  it('should work with multiple calls to updateCatAndGetNextItem', () => {
+    const clowderInput: ClowderInput = {
+      cats: {
+        cat1: { method: 'MLE', theta: 0.5 },
+      },
+      corpus: [
+        createMultiZetaStimulus('0', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('1', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('2', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('3', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('4', [createZetaCatMap(['cat1'])]),
+      ],
+    };
+
+    const clowder = new Clowder(clowderInput);
+
+    // First call: remove items 0 and 1
+    clowder.updateCatAndGetNextItem({
+      catToSelect: 'cat1',
+      additionalItemsToRemove: [clowder.corpus[0], clowder.corpus[1]],
+    });
+
+    expect(clowder.remainingItems).toHaveLength(3);
+
+    // Second call: remove item 2
+    clowder.updateCatAndGetNextItem({
+      catToSelect: 'cat1',
+      additionalItemsToRemove: [clowder.corpus[2]],
+    });
+
+    expect(clowder.remainingItems).toHaveLength(2);
+    expect(clowder.remainingItems.map((item) => item.id)).toEqual(['3', '4']);
+  });
+
+  it('should not affect ability estimate updates when using additionalItemsToRemove', () => {
+    const clowderInput: ClowderInput = {
+      cats: {
+        cat1: { method: 'MLE', theta: 0.5 },
+      },
+      corpus: [
+        createMultiZetaStimulus('0', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('1', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('2', [createZetaCatMap(['cat1'])]),
+      ],
+    };
+
+    const clowder = new Clowder(clowderInput);
+    const originalTheta = clowder.cats.cat1.theta;
+
+    clowder.updateCatAndGetNextItem({
+      catToSelect: 'cat1',
+      catsToUpdate: ['cat1'],
+      items: [clowder.corpus[0]],
+      answers: [1],
+      additionalItemsToRemove: [clowder.corpus[1]],
+    });
+
+    // Theta should be updated based on the presented item, not the additional items
+    expect(clowder.cats.cat1.theta).not.toBe(originalTheta);
+    expect(clowder.cats.cat1.nItems).toBe(1);
+  });
+
+  it('should handle additionalItemsToRemove with duplicate items in items array', () => {
+    const clowderInput: ClowderInput = {
+      cats: {
+        cat1: { method: 'MLE', theta: 0.5 },
+      },
+      corpus: [
+        createMultiZetaStimulus('0', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('1', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('2', [createZetaCatMap(['cat1'])]),
+        createMultiZetaStimulus('3', [createZetaCatMap(['cat1'])]),
+      ],
+    };
+
+    const clowder = new Clowder(clowderInput);
+
+    clowder.updateCatAndGetNextItem({
+      catToSelect: 'cat1',
+      catsToUpdate: ['cat1'],
+      items: [clowder.corpus[0]],
+      answers: [1],
+      additionalItemsToRemove: [clowder.corpus[1], clowder.corpus[2]],
+    });
+
+    // Items 0, 1, and 2 should be removed
+    expect(clowder.remainingItems).toHaveLength(1);
+    expect(clowder.remainingItems[0].id).toBe('3');
+  });
+});

--- a/src/clowder.ts
+++ b/src/clowder.ts
@@ -199,6 +199,7 @@ export class Clowder {
    * @param {(0 | 1) | (0 | 1)[]} [input.answers=[]] - An array of answers (0 or 1) corresponding to `items`.
    * @param {string} [input.method] - Optional method for updating ability estimates (if applicable).
    * @param {string} [input.itemSelect] - Optional item selection method (if applicable).
+   * @param {MultiZetaStimulus[]} [input.additionalItemsToRemove=[]] - Optional additional items to remove from the remainingItems.
    * @param {boolean} [input.randomlySelectUnvalidated=false] - Optional flag indicating whether to randomly select an unvalidated item for `catToSelect`.
    * @param {boolean} [input.returnUndefinedOnExhaustion=true] - Optional flag indicating whether to return undefined when no validated items are available.
    *
@@ -214,6 +215,7 @@ export class Clowder {
    * 2. Update:
    *    a. Updates the internal list of seen items.
    *    b. Updates the ability estimates for the `catsToUpdate`.
+   *    c. Removes the provided items from the remainingItems.
    * 3. Select:
    *    a. Selects the next item using `catToSelect`, considering only remaining items that are valid for that cat.
    *    b. If desired, randomly selects an unvalidated item for catToSelect.
@@ -227,6 +229,7 @@ export class Clowder {
     answers = [],
     method,
     itemSelect,
+    additionalItemsToRemove = [],
     randomlySelectUnvalidated = false,
     returnUndefinedOnExhaustion = true,
   }: {
@@ -238,6 +241,7 @@ export class Clowder {
     answers?: (0 | 1) | (0 | 1)[];
     method?: string;
     itemSelect?: string;
+    additionalItemsToRemove?: MultiZetaStimulus[];
     randomlySelectUnvalidated?: boolean;
     returnUndefinedOnExhaustion?: boolean; // New parameter type
   }): Stimulus | undefined {
@@ -265,7 +269,7 @@ export class Clowder {
     //           +----------------+
     // ----------|  Update Cats   |----------|
     //           +----------------+
-    this._updateCats(catsToUpdate, items, answers, method);
+    this._updateCats(catsToUpdate, items, answers, method, additionalItemsToRemove);
 
     //           +----------------+
     // ----------| Early Stopping |----------|
@@ -297,13 +301,21 @@ export class Clowder {
    * @param {MultiZetaStimulus[]} items - The items to update the ability estimates for.
    * @param {(0 | 1)[]} answers - The answers to the items.
    * @param {string} [method] - Optional method for updating ability estimates. If none is provided, it will use the default method for each Cat instance.
+   * @param {MultiZetaStimulus[]} [additionalItemsToRemove] - Optional additional items to remove from the remainingItems.
    */
-  private _updateCats(catsToUpdate: string[], items: MultiZetaStimulus[], answers: (0 | 1)[], method?: string) {
+  private _updateCats(
+    catsToUpdate: string[],
+    items: MultiZetaStimulus[],
+    answers: (0 | 1)[],
+    method?: string,
+    additionalItemsToRemove: MultiZetaStimulus[] = [],
+  ) {
     // Update the seenItems with the provided previous items
     this._seenItems.push(...items);
 
     // Remove the provided previous items from the remainingItems
     this._remainingItems = _differenceWith(this._remainingItems, items, _isEqual);
+    this._remainingItems = _differenceWith(this._remainingItems, additionalItemsToRemove, _isEqual);
 
     // Create a new zip array of items and answers. This will be useful in
     // filtering operations below. It ensures that items and their corresponding


### PR DESCRIPTION
Add `additionalItemsToRemove` param as an enhancement that will support cases (e.g. `roar-inference` -- where after showing a story, it would remove all 2-3 items for that story from the pool of available items.)